### PR TITLE
Removed ext:dummy="dummy" xlink:dummy="dummy" from MODS editor's UI

### DIFF
--- a/modules/edit/body/00-compact-contents-name-title.xml
+++ b/modules/edit/body/00-compact-contents-name-title.xml
@@ -1,5 +1,5 @@
 <!--node insertions: --><!--missing element insertion: --><!--hints moved to code-table: --><!--saving of all nodes: --><!--schema instantiated: --><!--schema notations added: --><!-- insert does not work with name -->
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-d" ext:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-d">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-contents.xml
+++ b/modules/edit/body/00-compact-contents.xml
@@ -1,4 +1,4 @@
-<div xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="compact block-form" tab-id="compact-c" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="compact block-form" tab-id="compact-c">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-main.xml
+++ b/modules/edit/body/00-compact-main.xml
@@ -1,4 +1,4 @@
-<div xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="compact block-form" tab-id="compact-a" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="compact block-form" tab-id="compact-a">
     <xf:group ref=".[mods:titleInfo]">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-article.xml
+++ b/modules/edit/body/00-compact-related-article.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-article" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-article">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-edited-volume.xml
+++ b/modules/edit/body/00-compact-related-edited-volume.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-edited-volume" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-edited-volume">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-monograph.xml
+++ b/modules/edit/body/00-compact-related-monograph.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-monograph" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-monograph">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-moving-images.xml
+++ b/modules/edit/body/00-compact-related-moving-images.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-moving-images" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-moving-images">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-newspaper-article.xml
+++ b/modules/edit/body/00-compact-related-newspaper-article.xml
@@ -1,4 +1,4 @@
-<div xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="compact block-form" tab-id="compact-b-newspaper-article" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="compact block-form" tab-id="compact-b-newspaper-article">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-other.xml
+++ b/modules/edit/body/00-compact-related-other.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-xlink" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-xlink">
     <xf:group ref=".[mods:relatedItem[@type='host']]">
         <fieldset class="level-1">
             <div class="label-box extra-wide">

--- a/modules/edit/body/00-compact-related-review.xml
+++ b/modules/edit/body/00-compact-related-review.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-review" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-review">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-suebs-chinese.xml
+++ b/modules/edit/body/00-compact-related-suebs-chinese.xml
@@ -1,5 +1,5 @@
 <!--node insertions: --><!--hints moved to code-table: --><!--hints checked: --><!--saving of all nodes: -->
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-suebs-chinese" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-suebs-chinese">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/00-compact-related-suebs-tibetan.xml
+++ b/modules/edit/body/00-compact-related-suebs-tibetan.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-suebs-tibetan" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="compact block-form" tab-id="compact-b-suebs-tibetan">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/01-titleInfo.xml
+++ b/modules/edit/body/01-titleInfo.xml
@@ -1,4 +1,4 @@
-<div xmlns="http://www.w3.org/1999/xhtml" xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="title block-form" tab-id="title" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns="http://www.w3.org/1999/xhtml" xmlns:ext="http://exist-db.org/mods/extension" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" class="title block-form" tab-id="title">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/02-name.xml
+++ b/modules/edit/body/02-name.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="name block-form" tab-id="name" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="name block-form" tab-id="name">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/03-originInfo.xml
+++ b/modules/edit/body/03-originInfo.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="origin block-form" tab-id="origin" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="origin block-form" tab-id="origin">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/04-part.xml
+++ b/modules/edit/body/04-part.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="part block-form" tab-id="part" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="part block-form" tab-id="part">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/05-physicalDescription.xml
+++ b/modules/edit/body/05-physicalDescription.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="physical-description block-form" tab-id="physical-description" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="physical-description block-form" tab-id="physical-description">
     <xf:group>
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/06-targetAudience.xml
+++ b/modules/edit/body/06-targetAudience.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="target-audience block-form" tab-id="target-audience" ext:dummy="dummy" xlink:dummy="dummy" xml:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="target-audience block-form" tab-id="target-audience" xml:dummy="dummy">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/07-language.xml
+++ b/modules/edit/body/07-language.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="language block-form" tab-id="language" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="language block-form" tab-id="language">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/08-type.xml
+++ b/modules/edit/body/08-type.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="type block-form" tab-id="type" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="type block-form" tab-id="type">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/09-genre.xml
+++ b/modules/edit/body/09-genre.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="genre block-form" tab-id="genre" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="genre block-form" tab-id="genre">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/10-subject.xml
+++ b/modules/edit/body/10-subject.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="subject block-form" tab-id="subject" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="subject block-form" tab-id="subject">
     <div class="block-form">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/11-classification.xml
+++ b/modules/edit/body/11-classification.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="classification block-form" tab-id="classification" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="classification block-form" tab-id="classification">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/12-abstract.xml
+++ b/modules/edit/body/12-abstract.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="abstract block-form" tab-id="abstract" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="abstract block-form" tab-id="abstract">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/13-tableOfContents.xml
+++ b/modules/edit/body/13-tableOfContents.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="table-of-contents block-form" tab-id="table-of-contents" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="table-of-contents block-form" tab-id="table-of-contents">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/14-note.xml
+++ b/modules/edit/body/14-note.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="note block-form" tab-id="note" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="note block-form" tab-id="note">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/15-relatedItem-abbreviated.xml
+++ b/modules/edit/body/15-relatedItem-abbreviated.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="related block-form" tab-id="related-abbreviated" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="related block-form" tab-id="related-abbreviated">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box super-wide">

--- a/modules/edit/body/15-relatedItem-xlink.xml
+++ b/modules/edit/body/15-relatedItem-xlink.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="related block-form" tab-id="related-xlink" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="related block-form" tab-id="related-xlink">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box extra-wide">

--- a/modules/edit/body/15-relatedItem.xml
+++ b/modules/edit/body/15-relatedItem.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="related block-form" tab-id="related" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="related block-form" tab-id="related">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box extra-wide">

--- a/modules/edit/body/16-identifier.xml
+++ b/modules/edit/body/16-identifier.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="identifier block-form" tab-id="identifier" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="identifier block-form" tab-id="identifier">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/17-recordInfo.xml
+++ b/modules/edit/body/17-recordInfo.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="record-info block-form" tab-id="record-info" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="record-info block-form" tab-id="record-info">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/18-location.xml
+++ b/modules/edit/body/18-location.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="location block-form" tab-id="location" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="location block-form" tab-id="location">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/19-accessCondition.xml
+++ b/modules/edit/body/19-accessCondition.xml
@@ -1,4 +1,4 @@
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="access-condition block-form" tab-id="access-condition" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="access-condition block-form" tab-id="access-condition">
     <xf:group appearance="full">
         <fieldset class="level-1 ">
             <div class="label-box">

--- a/modules/edit/body/20-extension.xml
+++ b/modules/edit/body/20-extension.xml
@@ -1,5 +1,5 @@
 <!--node insertions: insertion and deletion does not work, but this does not matter, since elements are inserted in edit.xq--><!--missing element insertion: does not work, but this does not matter, since elements are inserted in edit.xq--><!--hints moved to code-table: OK--><!--hints linked with id: OK--><!--hints checked: OK--><!--saving of all nodes: OK--><!--schema instantiated: n/a--><!--schema notations added: n/a-->
-<div xmlns:ev="http://www.w3.org/2001f/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="extension block-form" tab-id="extension" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001f/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:ext="http://exist-db.org/mods/extension" class="extension block-form" tab-id="extension">
     <xf:group appearance="full">
         <fieldset class="level-1">
             <div class="label-box">

--- a/modules/edit/body/21-mads.xml
+++ b/modules/edit/body/21-mads.xml
@@ -1,5 +1,5 @@
 <!--node insertions: --><!--missing element insertion: --><!--hints moved to code-table: --><!--hints linked with id: --><!--hints checked: --><!--saving of all nodes: --><!--schema instantiated: --><!--schema notations added: -->
-<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:mads="http://www.loc.gov/mads/" xmlns:ext="http://exist-db.org/mods/extension" class="mads block-form" tab-id="mads" ext:dummy="dummy" xlink:dummy="dummy">
+<div xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xf="http://www.w3.org/2002/xforms" xmlns:mads="http://www.loc.gov/mads/" xmlns:ext="http://exist-db.org/mods/extension" class="mads block-form" tab-id="mads">
     <xf:repeat nodeset="instance('save-data')/mads:authority" id="authority-repeat">
         <xf:group appearance="full">
             <fieldset class="level-1">


### PR DESCRIPTION
files.

References #1370.